### PR TITLE
Generator classes (and some refactoring)

### DIFF
--- a/fake_news/base.py
+++ b/fake_news/base.py
@@ -30,7 +30,7 @@ class AbstractNewsGenerator(ABC):
     @abstractmethod
     def generate(
         self,
-        title: str,
+        title: list[str],
         generation_config: GenerationConfig | dict[str, Any] | None = None,
-    ) -> str:
+    ) -> list[str]:
         pass

--- a/fake_news/base.py
+++ b/fake_news/base.py
@@ -29,6 +29,8 @@ class AbstractNewsClassifier(ABC):
 class AbstractNewsGenerator(ABC):
     @abstractmethod
     def generate(
-        self, title: str, generation_config: GenerationConfig | dict[str, Any]
+        self,
+        title: str,
+        generation_config: GenerationConfig | dict[str, Any] | None = None,
     ) -> str:
         pass

--- a/fake_news/base.py
+++ b/fake_news/base.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
+from typing import Any
 
 import numpy as np
+from transformers import GenerationConfig  # type: ignore
 
 
 class AbstractNewsClassifier(ABC):
@@ -25,16 +27,8 @@ class AbstractNewsClassifier(ABC):
 
 
 class AbstractNewsGenerator(ABC):
-    def __init__(self, **genParams):
-        self._generationParams = genParams
-
     @abstractmethod
-    def generate(self, title: str) -> str:
+    def generate(
+        self, title: str, generation_config: GenerationConfig | dict[str, Any]
+    ) -> str:
         pass
-
-    def setGenerationParameter(self, paramName: str, value):
-        """
-        Value can be of any type, so I'm not adding a hint
-        """
-        if paramName in self._generationParams:
-            self._generationParams[paramName] = value

--- a/fake_news/generator_evaluation.py
+++ b/fake_news/generator_evaluation.py
@@ -30,7 +30,7 @@ def evaluateGenerator(
     generator: base.AbstractNewsGenerator,
     classifiers: dict[str, tuple[base.AbstractNewsClassifier, str]],
     testTitles: list[str],
-    paramValues: dict[str, Any],
+    paramValues: dict[str, list[Any]],
     dataPreprocessor: DataPreprocessingBeforeClassifiers,
 ) -> pd.DataFrame:
     """
@@ -71,16 +71,15 @@ def evaluateGenerator(
     ]  # Generate all possible generation parameters combinations
 
     for paramCombination in paramsCombinations:
-        for paramName in paramCombination:
-            generator.setGenerationParameter(
-                paramName=paramName, value=paramCombination[paramName]
-            )
-            res[paramName].append(paramCombination[paramName])
+        for paramName, paramVal in paramCombination.items():
+            res[paramName].append(paramVal)
         fakeNewsCountPerClassifier = {
             classifierName: 0 for classifierName in classifiers
         }
-        for testTitle in testTitles:
-            article = generator.generate(testTitle)
+        for testTitle in testTitles:  # TODO: perhaps use batch
+            article = generator.generate(
+                testTitle, generation_config=paramCombination
+            )
             for classifierName in classifiers:
                 classification = classifiers[classifierName][0].predict(
                     _preprocessArticle(

--- a/fake_news/generator_evaluation.py
+++ b/fake_news/generator_evaluation.py
@@ -78,8 +78,8 @@ def evaluateGenerator(
         }
         for testTitle in testTitles:  # TODO: perhaps use batch
             article = generator.generate(
-                testTitle, generation_config=paramCombination
-            )
+                [testTitle], generation_config=paramCombination
+            )[0]
             for classifierName in classifiers:
                 classification = classifiers[classifierName][0].predict(
                     _preprocessArticle(

--- a/fake_news/generators/t5.py
+++ b/fake_news/generators/t5.py
@@ -1,0 +1,54 @@
+from transformers import (  # type: ignore
+    T5Tokenizer,
+    T5ForConditionalGeneration,
+    GenerationConfig,
+)
+
+from typing import Any
+
+from fake_news.base import AbstractNewsGenerator
+
+
+class T5Generator(AbstractNewsGenerator):
+    def __init__(self, model_path: str = "AmevinLS/flan-t5-base-realnews"):
+        self.model = T5ForConditionalGeneration.from_pretrained(model_path)
+        self.tokenizer: T5Tokenizer = T5Tokenizer.from_pretrained(model_path)
+
+    def generate(
+        self,
+        titles: str | list[str],
+        generation_config: GenerationConfig | dict[str, Any] | None = None,
+    ) -> str:
+        PREFIX = "Please write an article based on the title: "
+        if isinstance(titles, str):
+            titles = [titles]
+        if isinstance(generation_config, dict):
+            generation_config = GenerationConfig(**generation_config)
+        elif generation_config is None:
+            generation_config = GenerationConfig()
+
+        input_tokens = self.tokenizer(
+            [PREFIX + title for title in titles],
+            return_tensors="pt",
+            padding=True,
+        )["input_ids"]
+        input_tokens = input_tokens.to(device=self.model.device)
+        output_tokens = self.model.generate(
+            input_tokens, generation_config=generation_config
+        )
+
+        return self.tokenizer.batch_decode(
+            output_tokens, skip_special_tokens=True
+        )
+
+
+if __name__ == "__main__":
+    generator = T5Generator()
+    output = generator.generate(
+        "Belarus under new set of sanctions",
+        {
+            "max_new_tokens": 200,
+            "repetition_penalty": 2.0,
+        },
+    )
+    print(output)

--- a/notebooks/data_preparation.ipynb
+++ b/notebooks/data_preparation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -167,7 +167,7 @@
        "[70793 rows x 3 columns]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ nltk
 tensorflow
 transformers
 sentencepiece
+peft
 --index-url https://download.pytorch.org/whl/cu118
 torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ jupyter
 nltk
 tensorflow
 transformers
+sentencepiece
+--index-url https://download.pytorch.org/whl/cu118
+torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ tensorflow
 transformers
 sentencepiece
 peft
---index-url https://download.pytorch.org/whl/cu118
-torch
+torch --index-url https://download.pytorch.org/whl/cu118

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scikit-learn
 jupyter
 nltk
 tensorflow
+transformers

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,6 @@ tensorflow
 transformers
 sentencepiece
 peft
-torch --index-url https://download.pytorch.org/whl/cu118
+# To install torch with gpu run
+# pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu118
+torch


### PR DESCRIPTION
- Generator classes for `phi-2`, `tinyllama`, `flan-t5`
- Switch to batch-only generation for all generators
- Refactor to passing GenerationConfig/dict when calling `generate()` method